### PR TITLE
Fixed ZSH payload

### DIFF
--- a/pkg/echoify.go
+++ b/pkg/echoify.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-var PRINTABLE = []byte("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&()*+,-./:;<=>?@[]^_`{|}~ ")
+var PRINTABLE = []byte("0123456789abcdefghijklmnopqrstuvwyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&()*+,-./:;<=>?@[]^_`{|}~")
 var NUMERIC = []byte("0123456789")
 
 func EchoifyData(data []byte) string {


### PR DESCRIPTION
The current payload generator does not work when pasting into a `zsh` shell. This is due to how `zsh` processes escape sequences such as `\0x` and those with whitespace. This can be fixed by encoding the `x` character and spaces.